### PR TITLE
fetch E4S key from new server

### DIFF
--- a/setup/install-deps.sh
+++ b/setup/install-deps.sh
@@ -77,7 +77,8 @@ if $INSTALL_ASCENT; then
     . spack/share/spack/setup-env.sh
     spack -e . concretize -f 2>&1 | tee concretize.log
     spack mirror add e4s_summit https://cache.e4s.io 
-    spack buildcache keys -it
+    wget https://oaciss.uoregon.edu/e4s/e4s.pub
+    spack gpg trust e4s.pub
     module load patchelf
 
     if $USE_SPACK_CACHE; then


### PR DESCRIPTION
For the time being we can't fetch the E4S public key using `spack buildcache keys -it`.

Instead, what we can do is fetch the key directly from `https://oaciss.uoregon.edu/e4s/e4s.pub`